### PR TITLE
Correctly pass event arguments

### DIFF
--- a/can-simple-map.js
+++ b/can-simple-map.js
@@ -19,7 +19,7 @@ var SimpleMap = Construct.extend({
 		if(arguments.length > 1) {
 			var old = this._data[prop];
 			this._data[prop] = value;
-			canBatch.trigger.call(this, prop, [old]);
+			canBatch.trigger.call(this, prop, [value, old]);
 		} else if(typeof prop === 'object') {
 			Object.keys(prop).forEach(function(key) {
 				self.attr(key, prop[key]);

--- a/can-simple-map_test.js
+++ b/can-simple-map_test.js
@@ -10,11 +10,12 @@ QUnit.test("adds defaultMap type", function() {
 	QUnit.ok(map instanceof SimpleMap);
 });
 
-QUnit.test("instantiates and gets events", 1, function() {
+QUnit.test("instantiates and gets events", 2, function() {
 	var map = new SimpleMap({ age: 29 });
 
-	map.on('age', function(ev, old) {
-		QUnit.equal(old, 29);
+	map.on('age', function(ev, newVal, oldVal) {
+		QUnit.equal(oldVal, 29);
+		QUnit.equal(newVal, 30);
 	});
 
 	map.attr('age', 30);


### PR DESCRIPTION
This fixes event arguments for when a change occurs in `.attr()`. The
newVal should be first then the oldVal.