### PR TITLE
Ensuring types.DefaultMap test works

### DIFF
--- a/can-simple-map_test.js
+++ b/can-simple-map_test.js
@@ -1,13 +1,23 @@
 var QUnit = require('steal-qunit');
 var SimpleMap = require('./can-simple-map');
 var compute = require('can-compute');
-var types = require("can-util/js/types/types");
+var clone = require('steal-clone');
 
 QUnit.module('can-simple-map');
 
 QUnit.test("adds defaultMap type", function() {
-	var map = new types.DefaultMap();
-	QUnit.ok(map instanceof SimpleMap);
+	stop();
+	var c = clone();
+
+	// ensure types.DefaultMap is not impacted by
+	// other map types that may have been loaded
+	c.import('can-util/js/types/types').then(function(types) {
+		c.import('./can-simple-map').then(function(SimpleMap) {
+			var map = new types.DefaultMap();
+			QUnit.ok(map instanceof SimpleMap);
+			start();
+		});
+	});
 });
 
 QUnit.test("instantiates and gets events", 2, function() {


### PR DESCRIPTION
This test now uses steal-clone to load can-util/js/types/
separately from other modules. This will ensure that this test
works even if can-map or can-define/map/map are loaded prior
to this test loading.

Closes https://github.com/canjs/can-simple-map/issues/5.