### PR TITLE
chore(package): update can-event to version 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "can-cid": "^1.0.3",
     "can-construct": "^3.2.0-pre.0",
-    "can-event": "^3.5.0-pre.2",
+    "can-event": "^3.6.0",
     "can-observation": "^3.3.1",
     "can-reflect": "^1.2.1",
     "can-symbol": "^1.0.0-pre.0",


### PR DESCRIPTION
Closes #34 