### PR TITLE
Implement `.log` to log map property changes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,7 +21,8 @@
 		"start": true,
 		"stop": true,
 		"global": true,
-		"Promise": true
+		"Promise": true,
+		"Set": true
 	},
 	"strict": false,
 	"curly": true,

--- a/can-simple-map_test.js
+++ b/can-simple-map_test.js
@@ -4,8 +4,14 @@ var clone = require('steal-clone');
 var canSymbol = require('can-symbol');
 var canReflect = require('can-reflect');
 var Observation = require("can-observation");
+var dev = require("can-log/dev/dev");
 
 QUnit.module('can-simple-map');
+
+QUnit.test("sets constructor name", function(assert) {
+	var map = new SimpleMap();
+	assert.equal(map.constructor.name, "SimpleMap");
+});
 
 QUnit.test("adds defaultMap type", function() {
 	stop();
@@ -153,4 +159,80 @@ QUnit.test("registered symbols", function() {
 
 	a[canSymbol.for("can.offKeyValue")]("a", handler);
 	a.attr("a", "d"); // doesn't trigger handler
+});
+
+QUnit.test("log all property changes", function(assert) {
+	var map = new SimpleMap();
+	var done = assert.async();
+
+	map.log();
+
+	var changed = [];
+	var log = dev.log;
+	dev.log = function() {
+		changed.push(JSON.parse(arguments[2]));
+	};
+
+	map.set("foo","bar");
+	map.set({zed: "ted"});
+
+	var deepMap = new SimpleMap({a: "b"});
+	map.set("deep", deepMap);
+
+	assert.expect(1);
+	setTimeout(function() {
+		dev.log = log;
+		assert.deepEqual(changed, ["foo", "zed", "deep"], "should log all properties");
+		done();
+	});
+});
+
+QUnit.test("log single property changes", function(assert) {
+	var map = new SimpleMap();
+	var done = assert.async();
+
+	map.log("foo");
+
+	var changed = [];
+	var log = dev.log;
+	dev.log = function() {
+		changed.push(JSON.parse(arguments[2]));
+	};
+
+	map.set("foo", "bar");
+	map.set("bar", "bar");
+	map.set("baz", "baz");
+
+	assert.expect(1);
+	setTimeout(function() {
+		dev.log = log;
+		assert.deepEqual(changed, ["foo"], "should only log 'foo' changes");
+		done();
+	});
+});
+
+QUnit.test("log multiple property changes", function(assert) {
+	var map = new SimpleMap();
+	var done = assert.async();
+
+	map.log("foo");
+	map.log("qux");
+
+	var changed = [];
+	var log = dev.log;
+	dev.log = function() {
+		changed.push(JSON.parse(arguments[2]));
+	};
+
+	map.set("foo", "foo");
+	map.set("bar", "bar");
+	map.set("baz", "baz");
+	map.set("qux", "qux");
+
+	assert.expect(1);
+	setTimeout(function() {
+		dev.log = log;
+		assert.deepEqual(changed, ["foo", "qux"], "should log onlt foo and qux");
+		done();
+	});
 });

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "can-construct": "^3.2.0",
     "can-event-queue": "<2.0.0",
     "can-key-tree": "<2.0.0",
+    "can-log": "^0.1.0",
     "can-observation": "^4.0.0-pre.0",
     "can-observation-recorder": "<2.0.0",
     "can-queues": "<2.0.0",


### PR DESCRIPTION
Example output:

![screen shot 2017-10-17 at 15 05 12](https://user-images.githubusercontent.com/724877/31691031-d38d66b8-b351-11e7-8a5c-1f7bc8895275.png)
