### PR TITLE
fix dev code for webpack compatibility

### DIFF
--- a/can-simple-map.js
+++ b/can-simple-map.js
@@ -207,7 +207,7 @@ var simpleMapProto = {
 
 //!steal-remove-start
 if (process.env.NODE_ENV !== 'production') {
-	simpleMapProto[canSymbol.for("can.getName")] = function() {
+	simpleMapProto["can.getName"] = function() {
 		return canReflect.getName(this.constructor) + "{}";
 	};
 }

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <title>can-simple-map</title>
 <script src="../node_modules/steal/steal.js" main="test/test"></script>
 <div id="qunit-fixture"></div>


### PR DESCRIPTION
This fixes the first part of this issue canjs/canjs#4170 to remove debug code from the production builds.